### PR TITLE
Make colors generator public to allow for customized colors for chart

### DIFF
--- a/src/Chart.php
+++ b/src/Chart.php
@@ -46,7 +46,7 @@ class Chart extends View
     protected $datasets;
 
     /** @var ColorGenerator */
-    protected $colorGenerator;
+    public $colorGenerator;
 
     protected function init(): void
     {

--- a/src/ColorGenerator.php
+++ b/src/ColorGenerator.php
@@ -16,7 +16,7 @@ class ColorGenerator
      *
      * @var array<int, array<int, string>>
      */
-    protected $colors = [
+    public $colors = [
         ['rgba(255, 99, 132, 0.2)', 'rgba(255, 99, 132, 1)'],
         ['rgba(54, 162, 235, 0.2)', 'rgba(54, 162, 235, 1)'],
         ['rgba(255, 206, 86, 0.2)', 'rgba(255, 206, 86, 1)'],


### PR DESCRIPTION
Beyond having an automatied ColorGenerator, it needs to be possible to set the colour scheme per chart easily. Thus, both ColorGenerator and its $color definition should be public.