### PR TITLE
Fix JS expression for chart label typo

### DIFF
--- a/demos/index.php
+++ b/demos/index.php
@@ -34,7 +34,7 @@ $t = [
 
 $m = new Model(new Persistence\Array_($t));
 $m->addFields(['name', 'sales_cash', 'sales_bank', 'sales', 'purchases', 'profit']);
-$m->onHook(Model::HOOK_AFTER_LOAD, static function (Model $m) {
+$m->onHook(Model::HOOK_AFTER_LOAD, function (Model $m) {
     $m->set('sales', $m->get('sales_cash') + $m->get('sales_bank'));
     $m->set('profit', $m->get('sales') - $m->get('purchases'));
 });

--- a/demos/index.php
+++ b/demos/index.php
@@ -34,7 +34,7 @@ $t = [
 
 $m = new Model(new Persistence\Array_($t));
 $m->addFields(['name', 'sales_cash', 'sales_bank', 'sales', 'purchases', 'profit']);
-$m->onHook(Model::HOOK_AFTER_LOAD, function (Model $m) {
+$m->onHook(Model::HOOK_AFTER_LOAD, static function (Model $m) {
     $m->set('sales', $m->get('sales_cash') + $m->get('sales_bank'));
     $m->set('profit', $m->get('sales') - $m->get('purchases'));
 });

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -231,13 +231,13 @@ class Chart extends View
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
                             new JsExpression(<<<'EOF'
-                                    let label = context.dataset.label || '';
-                                    // let value = context.parsed.y; // or x (horizontal) or r (radar) etc
-                                    let value = context.formattedValue.replace(/,/, '');
-                                    if (label) {
-                                        label += ': ';
-                                    }
-                                    return label + (value ? [char] + Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : 'No Data');
+                                let label = context.dataset.label || '';
+                                // let value = context.parsed.y; // or x (horizontal) or r (radar) etc
+                                let value = context.formattedValue.replace(/,/, '');
+                                if (label) {
+                                    label += ': ';
+                                }
+                                return label + (value ? [char] + Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : 'No Data');
                                 EOF, ['char' => $char, 'digits' => $digits]),
                         ]),
                     ],

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -237,8 +237,9 @@ class Chart extends View
                                 if (label) {
                                     label += ": ";
                                 }
-                                return label + (value ? "' . $char . ' " +  Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: ' . $digits . '}) : "No Data");
-                                EOF),
+                                EOF .'
+                                return label + (value ? "' . $char . ' " +  Number(value).toLocaleString(undefined, {minimumFractionDigits: '.$digits. ', maximumFractionDigits: '.$digits.'}) : "No Data")'
+                            ),
                         ]),
                     ],
                 ],

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -230,14 +230,15 @@ class Chart extends View
                     'mode' => 'point',
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
-                            new JsExpression(<<<'EOF'
-                                let label = context.dataset.label || "";
-                                // let value = context.parsed.y; // or x (horizontal) or r (radar) etc
-                                let value = context.formattedValue.replace(/,/, "");
-                                if (label) {
-                                    label += ": ";
-                                }
-                                EOF .'
+                            new JsExpression(
+                                <<<'EOF'
+                                    let label = context.dataset.label || "";
+                                    // let value = context.parsed.y; // or x (horizontal) or r (radar) etc
+                                    let value = context.formattedValue.replace(/,/, "");
+                                    if (label) {
+                                        label += ": ";
+                                    }
+                                    EOF .'
                                 return label + (value ? "' . $char . ' " +  Number(value).toLocaleString(undefined, {minimumFractionDigits: '.$digits. ', maximumFractionDigits: '.$digits.'}) : "No Data")'
                             ),
                         ]),

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -239,7 +239,7 @@ class Chart extends View
                                         label += ": ";
                                     }
                                     EOF . '
-                                return label + (value ? "' . $char . ' " +  Number(value).toLocaleString(undefined, {minimumFractionDigits: '. $digits . ', maximumFractionDigits: '. $digits . '}) : "No Data")'
+                                return label + (value ? "' . $char . ' " +  Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: '. $digits . '}) : "No Data")'
                             ),
                         ]),
                     ],

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -237,7 +237,7 @@ class Chart extends View
                                     if (label) {
                                         label += ": ";
                                     }
-                                    return label + (value ? [char] +  Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : "No Data");
+                                    return label + (value ? [char] + Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : "No Data");
                                 EOF, ['char' => $char, 'digits' => $digits]),
                         ]),
                     ],

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -238,7 +238,7 @@ class Chart extends View
                                     if (label) {
                                         label += ": ";
                                     }
-                                return label + (value ? [] +  Number(value).toLocaleString(undefined, {minimumFractionDigits: [], maximumFractionDigits: []}) : "No Data")
+                                    return label + (value ? [] +  Number(value).toLocaleString(undefined, {minimumFractionDigits: [], maximumFractionDigits: []}) : "No Data")
                                 EOF,
                             [$char, $digits, $digits]),
                         ]),

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -238,9 +238,8 @@ class Chart extends View
                                     if (label) {
                                         label += ": ";
                                     }
-                                    EOF . '
-                                return label + (value ? "' . $char . ' " +  Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: ' . $digits . '}) : "No Data")'
-                            ),
+                                return label + (value ? [] +  Number(value).toLocaleString(undefined, {minimumFractionDigits: [], maximumFractionDigits: []}) : "No Data")
+                                EOF, [$char, $digits, $digits]),
                         ]),
                     ],
                 ],

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -232,15 +232,16 @@ class Chart extends View
                         'label' => new JsFunction(['context'], [
                             new JsExpression(
                                 <<<'EOF'
-                                    let label = context.dataset.label || "";
-                                    // let value = context.parsed.y; // or x (horizontal) or r (radar) etc
-                                    let value = context.formattedValue.replace(/,/, "");
-                                    if (label) {
-                                        label += ": ";
-                                    }
-                                    return label + (value ? [] +  Number(value).toLocaleString(undefined, {minimumFractionDigits: [], maximumFractionDigits: []}) : "No Data")
-                                EOF,
-                            [$char, $digits, $digits]),
+                                        let label = context.dataset.label || "";
+                                        // let value = context.parsed.y; // or x (horizontal) or r (radar) etc
+                                        let value = context.formattedValue.replace(/,/, "");
+                                        if (label) {
+                                            label += ": ";
+                                        }
+                                        return label + (value ? [] +  Number(value).toLocaleString(undefined, {minimumFractionDigits: [], maximumFractionDigits: []}) : "No Data")
+                                    EOF,
+                                [$char, $digits, $digits]
+                            ),
                         ]),
                     ],
                 ],

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -230,18 +230,15 @@ class Chart extends View
                     'mode' => 'point',
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
-                            new JsExpression(
-                                <<<'EOF'
-                                        let label = context.dataset.label || "";
-                                        // let value = context.parsed.y; // or x (horizontal) or r (radar) etc
-                                        let value = context.formattedValue.replace(/,/, "");
-                                        if (label) {
-                                            label += ": ";
-                                        }
-                                        return label + (value ? [] +  Number(value).toLocaleString(undefined, {minimumFractionDigits: [], maximumFractionDigits: []}) : "No Data")
-                                    EOF,
-                                [$char, $digits, $digits]
-                            ),
+                            new JsExpression(<<<'EOF'
+                                let label = context.dataset.label || "";
+                                // let value = context.parsed.y; // or x (horizontal) or r (radar) etc
+                                let value = context.formattedValue.replace(/,/, "");
+                                if (label) {
+                                    label += ": ";
+                                }
+                                return label + (value ? "' . $char . ' " +  Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: ' . $digits . '}) : "No Data");
+                                EOF),
                         ]),
                     ],
                 ],

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -239,7 +239,8 @@ class Chart extends View
                                         label += ": ";
                                     }
                                 return label + (value ? [] +  Number(value).toLocaleString(undefined, {minimumFractionDigits: [], maximumFractionDigits: []}) : "No Data")
-                                EOF, [$char, $digits, $digits]),
+                                EOF,
+                            [$char, $digits, $digits]),
                         ]),
                     ],
                 ],

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -238,7 +238,7 @@ class Chart extends View
                                     if (label) {
                                         label += ": ";
                                     }
-                                    EOF .'
+                                    EOF . '
                                 return label + (value ? "' . $char . ' " +  Number(value).toLocaleString(undefined, {minimumFractionDigits: '.$digits. ', maximumFractionDigits: '.$digits.'}) : "No Data")'
                             ),
                         ]),

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -231,14 +231,14 @@ class Chart extends View
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
                             new JsExpression(<<<'EOF'
-                                let label = context.dataset.label || "";
-                                // let value = context.parsed.y; // or x (horizontal) or r (radar) etc
-                                let value = context.formattedValue.replace(/,/, "");
-                                if (label) {
-                                    label += ": ";
-                                }
-                                return label + (value ? "' . $char . ' " +  Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: ' . $digits . '}) : "No Data");
-                                EOF),
+                                    let label = context.dataset.label || "";
+                                    // let value = context.parsed.y; // or x (horizontal) or r (radar) etc
+                                    let value = context.formattedValue.replace(/,/, "");
+                                    if (label) {
+                                        label += ": ";
+                                    }
+                                    return label + (value ? [char] +  Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : "No Data");
+                                EOF, ['char' => $char, 'digits' => $digits]),
                         ]),
                     ],
                 ],

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -239,7 +239,7 @@ class Chart extends View
                                         label += ": ";
                                     }
                                     EOF . '
-                                return label + (value ? "' . $char . ' " +  Number(value).toLocaleString(undefined, {minimumFractionDigits: '.$digits. ', maximumFractionDigits: '.$digits.'}) : "No Data")'
+                                return label + (value ? "' . $char . ' " +  Number(value).toLocaleString(undefined, {minimumFractionDigits: '. $digits . ', maximumFractionDigits: '. $digits . '}) : "No Data")'
                             ),
                         ]),
                     ],

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -231,13 +231,13 @@ class Chart extends View
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
                             new JsExpression(<<<'EOF'
-                                    let label = context.dataset.label || "";
+                                    let label = context.dataset.label || '';
                                     // let value = context.parsed.y; // or x (horizontal) or r (radar) etc
-                                    let value = context.formattedValue.replace(/,/, "");
+                                    let value = context.formattedValue.replace(/,/, '');
                                     if (label) {
-                                        label += ": ";
+                                        label += ': ';
                                     }
-                                    return label + (value ? [char] + Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : "No Data");
+                                    return label + (value ? [char] + Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : 'No Data');
                                 EOF, ['char' => $char, 'digits' => $digits]),
                         ]),
                     ],

--- a/src/Chart.php
+++ b/src/Chart.php
@@ -239,7 +239,7 @@ class Chart extends View
                                         label += ": ";
                                     }
                                     EOF . '
-                                return label + (value ? "' . $char . ' " +  Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: '. $digits . '}) : "No Data")'
+                                return label + (value ? "' . $char . ' " +  Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: ' . $digits . '}) : "No Data")'
                             ),
                         ]),
                     ],

--- a/src/PieChart.php
+++ b/src/PieChart.php
@@ -60,15 +60,17 @@ class PieChart extends Chart
                     'mode' => 'point',
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
-                            new JsExpression(<<<'EOF'
-                                let label = context.dataset.label || "";
-                                // let value = context.parsed; // y or x (horizontal) or r (radar) etc
-                                let value = context.formattedValue.replace(/,/, "");
-                                if (label) {
-                                    label += ": ";
-                                }
-                                return label + (value ? "' . $char . ' " + Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: ' . $digits . '}) : "No Data");
-                                EOF),
+                            new JsExpression(
+                                <<<'EOF'
+                                    let label = context.dataset.label || "";
+                                    // let value = context.parsed; // y or x (horizontal) or r (radar) etc
+                                    let value = context.formattedValue.replace(/,/, "");
+                                    if (label) {
+                                        label += ": ";
+                                    }
+                                    return label + (value ? [] + Number(value).toLocaleString(undefined, {minimumFractionDigits: [], maximumFractionDigits: []}) : "No Data");
+                                EOF, [$char, $digits, $digits]
+                            ),
                         ]),
                     ],
                 ],

--- a/src/PieChart.php
+++ b/src/PieChart.php
@@ -61,13 +61,13 @@ class PieChart extends Chart
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
                             new JsExpression(<<<'EOF'
-                                    let label = context.dataset.label || '';
-                                    // let value = context.parsed; // y or x (horizontal) or r (radar) etc
-                                    let value = context.formattedValue.replace(/,/, '');
-                                    if (label) {
-                                        label += ': ';
-                                    }
-                                    return label + (value ? [char] + Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : 'No Data');
+                                let label = context.dataset.label || '';
+                                // let value = context.parsed; // y or x (horizontal) or r (radar) etc
+                                let value = context.formattedValue.replace(/,/, '');
+                                if (label) {
+                                    label += ': ';
+                                }
+                                return label + (value ? [char] + Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : 'No Data');
                                 EOF, ['char' => $char, 'digits' => $digits]),
                         ]),
                     ],

--- a/src/PieChart.php
+++ b/src/PieChart.php
@@ -60,18 +60,15 @@ class PieChart extends Chart
                     'mode' => 'point',
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
-                            new JsExpression(
-                                <<<'EOF'
-                                        let label = context.dataset.label || "";
-                                        // let value = context.parsed; // y or x (horizontal) or r (radar) etc
-                                        let value = context.formattedValue.replace(/,/, "");
-                                        if (label) {
-                                            label += ": ";
-                                        }
-                                        return label + (value ? [] + Number(value).toLocaleString(undefined, {minimumFractionDigits: [], maximumFractionDigits: []}) : "No Data");
-                                    EOF,
-                                [$char, $digits, $digits]
-                            ),
+                            new JsExpression(<<<'EOF'
+                                let label = context.dataset.label || "";
+                                // let value = context.parsed; // y or x (horizontal) or r (radar) etc
+                                let value = context.formattedValue.replace(/,/, "");
+                                if (label) {
+                                    label += ": ";
+                                }
+                                return label + (value ? "' . $char . ' " + Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: ' . $digits . '}) : "No Data");
+                                EOF),
                         ]),
                     ],
                 ],

--- a/src/PieChart.php
+++ b/src/PieChart.php
@@ -61,13 +61,13 @@ class PieChart extends Chart
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
                             new JsExpression(<<<'EOF'
-                                    let label = context.dataset.label || "";
+                                    let label = context.dataset.label || '';
                                     // let value = context.parsed; // y or x (horizontal) or r (radar) etc
-                                    let value = context.formattedValue.replace(/,/, "");
+                                    let value = context.formattedValue.replace(/,/, '');
                                     if (label) {
-                                        label += ": ";
+                                        label += ': ';
                                     }
-                                    return label + (value ? [char] + Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : "No Data");
+                                    return label + (value ? [char] + Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : 'No Data');
                                 EOF, ['char' => $char, 'digits' => $digits]),
                         ]),
                     ],

--- a/src/PieChart.php
+++ b/src/PieChart.php
@@ -61,14 +61,14 @@ class PieChart extends Chart
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
                             new JsExpression(<<<'EOF'
-                                let label = context.dataset.label || "";
-                                // let value = context.parsed; // y or x (horizontal) or r (radar) etc
-                                let value = context.formattedValue.replace(/,/, "");
-                                if (label) {
-                                    label += ": ";
-                                }
-                                return label + (value ? "' . $char . ' " + Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: ' . $digits . '}) : "No Data");
-                                EOF),
+                                    let label = context.dataset.label || "";
+                                    // let value = context.parsed; // y or x (horizontal) or r (radar) etc
+                                    let value = context.formattedValue.replace(/,/, "");
+                                    if (label) {
+                                        label += ": ";
+                                    }
+                                    return label + (value ? [char] + Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : "No Data");
+                                EOF, ['char' => $char, 'digits' => $digits]),
                         ]),
                     ],
                 ],

--- a/src/PieChart.php
+++ b/src/PieChart.php
@@ -62,14 +62,15 @@ class PieChart extends Chart
                         'label' => new JsFunction(['context'], [
                             new JsExpression(
                                 <<<'EOF'
-                                    let label = context.dataset.label || "";
-                                    // let value = context.parsed; // y or x (horizontal) or r (radar) etc
-                                    let value = context.formattedValue.replace(/,/, "");
-                                    if (label) {
-                                        label += ": ";
-                                    }
-                                    return label + (value ? [] + Number(value).toLocaleString(undefined, {minimumFractionDigits: [], maximumFractionDigits: []}) : "No Data");
-                                EOF, [$char, $digits, $digits]
+                                        let label = context.dataset.label || "";
+                                        // let value = context.parsed; // y or x (horizontal) or r (radar) etc
+                                        let value = context.formattedValue.replace(/,/, "");
+                                        if (label) {
+                                            label += ": ";
+                                        }
+                                        return label + (value ? [] + Number(value).toLocaleString(undefined, {minimumFractionDigits: [], maximumFractionDigits: []}) : "No Data");
+                                    EOF,
+                                [$char, $digits, $digits]
                             ),
                         ]),
                     ],

--- a/src/ScatterChart.php
+++ b/src/ScatterChart.php
@@ -82,12 +82,12 @@ class ScatterChart extends Chart
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
                             new JsExpression(<<<'EOF'
-                                    let label = context.dataset.label || "";
+                                    let label = context.dataset.label || '';
                                     let value = context.parsed.y;
                                     if (label) {
-                                        label += ": ";
+                                        label += ': ';
                                     }
-                                    return label + (value ? Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : "No Data");
+                                    return label + (value ? Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : 'No Data');
                                 EOF, ['digits' => $digits]),
                         ]),
                     ],

--- a/src/ScatterChart.php
+++ b/src/ScatterChart.php
@@ -81,14 +81,17 @@ class ScatterChart extends Chart
                     'mode' => 'point',
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
-                            new JsExpression(<<<'EOF'
-                                let label = context.dataset.label || "";
-                                let value = context.parsed.y;
-                                if (label) {
-                                    label += ": ";
-                                }
-                                return label + (value ? Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: ' . $digits . '}) : "No Data");
-                                EOF),
+                            new JsExpression(
+                               <<<'EOF'
+                                        let label = context.dataset.label || "";
+                                        let value = context.parsed.y;
+                                        if (label) {
+                                            label += ": ";
+                                        }
+                                        return label + (value ? Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: ' . $digits . '}) : "No Data");
+                                    EOF.
+                                [$char, $digits, $digits]
+                           ),
                         ]),
                     ],
                 ],

--- a/src/ScatterChart.php
+++ b/src/ScatterChart.php
@@ -82,12 +82,12 @@ class ScatterChart extends Chart
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
                             new JsExpression(<<<'EOF'
-                                    let label = context.dataset.label || '';
-                                    let value = context.parsed.y;
-                                    if (label) {
-                                        label += ': ';
-                                    }
-                                    return label + (value ? Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : 'No Data');
+                                let label = context.dataset.label || '';
+                                let value = context.parsed.y;
+                                if (label) {
+                                    label += ': ';
+                                }
+                                return label + (value ? Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : 'No Data');
                                 EOF, ['digits' => $digits]),
                         ]),
                     ],

--- a/src/ScatterChart.php
+++ b/src/ScatterChart.php
@@ -82,13 +82,13 @@ class ScatterChart extends Chart
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
                             new JsExpression(<<<'EOF'
-                                let label = context.dataset.label || "";
-                                let value = context.parsed.y;
-                                if (label) {
-                                    label += ": ";
-                                }
-                                return label + (value ? Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: ' . $digits . '}) : "No Data");
-                                EOF),
+                                    let label = context.dataset.label || "";
+                                    let value = context.parsed.y;
+                                    if (label) {
+                                        label += ": ";
+                                    }
+                                    return label + (value ? Number(value).toLocaleString(undefined, {minimumFractionDigits: [digits], maximumFractionDigits: [digits]}) : "No Data");
+                                EOF, ['digits' => $digits]),
                         ]),
                     ],
                 ],

--- a/src/ScatterChart.php
+++ b/src/ScatterChart.php
@@ -81,17 +81,14 @@ class ScatterChart extends Chart
                     'mode' => 'point',
                     'callbacks' => [
                         'label' => new JsFunction(['context'], [
-                            new JsExpression(
-                               <<<'EOF'
-                                        let label = context.dataset.label || "";
-                                        let value = context.parsed.y;
-                                        if (label) {
-                                            label += ": ";
-                                        }
-                                        return label + (value ? Number(value).toLocaleString(undefined, {minimumFractionDigits: [], maximumFractionDigits: []}) : "No Data");
-                                    EOF.
-                                [$digits, $digits]
-                           ),
+                            new JsExpression(<<<'EOF'
+                                let label = context.dataset.label || "";
+                                let value = context.parsed.y;
+                                if (label) {
+                                    label += ": ";
+                                }
+                                return label + (value ? Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: ' . $digits . '}) : "No Data");
+                                EOF),
                         ]),
                     ],
                 ],

--- a/src/ScatterChart.php
+++ b/src/ScatterChart.php
@@ -88,9 +88,9 @@ class ScatterChart extends Chart
                                         if (label) {
                                             label += ": ";
                                         }
-                                        return label + (value ? Number(value).toLocaleString(undefined, {minimumFractionDigits: ' . $digits . ', maximumFractionDigits: ' . $digits . '}) : "No Data");
+                                        return label + (value ? Number(value).toLocaleString(undefined, {minimumFractionDigits: [], maximumFractionDigits: []}) : "No Data");
                                     EOF.
-                                [$char, $digits, $digits]
+                                [$digits, $digits]
                            ),
                         ]),
                     ],


### PR DESCRIPTION
Variables in JS expression not processed due to EOF string definition

Effect: Tooltips are no longer working as originally intended.
How to test: Open the `demos/index.php` and check if tooltips work on all the charts. Also there should not be a JS console error as previously an invalid parameter is passed to `minimumFractionDigits`